### PR TITLE
dostosowanie do nowego api

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,18 +30,17 @@ func main() {
 	log.Printf("Loaded configuration: DOMAIN=%s; PORT=%s; SMTP_HOST=%s; SMTP_PORT=%s;", domain, port, smtpHost, smtpPort)
 
 	http.HandleFunc("/sms.do", func(w http.ResponseWriter, r *http.Request) {
-		username := r.URL.Query().Get("username")
 		from := r.URL.Query().Get("from")
 		to := r.URL.Query().Get("to")
 		message := r.URL.Query().Get("message")
 		w.Header().Add("Content-Type", "text/plain")
 
-		if status, err := sendMessage(username, from, to, message); err != nil {
+		if status, err := sendMessage(from, to, message); err != nil {
 			http.Error(w, err.Error(), status)
 			return
 		}
 
-		if _, err := fmt.Fprintf(w, "OK:1234:1:%s", to); err != nil {
+		if _, err := fmt.Fprint(w, "OK:1234:1"); err != nil {
 			log.Printf("Error: %s", err)
 		}
 	})
@@ -60,15 +59,15 @@ func getenv(variable string, defaultVal string) string {
 	return val
 }
 
-func sendMessage(username string, from string, to string, message string) (status int, error error) {
+func sendMessage(from string, to string, message string) (status int, error error) {
 	c, err := smtp.Dial(fmt.Sprintf("%s:%s", smtpHost, smtpPort))
 	if err != nil {
 		log.Printf("Cannot connect to smtp host: %s:%s: %s", smtpHost, smtpPort, err)
 		return http.StatusServiceUnavailable, fmt.Errorf("smtp service unavailable")
 	}
 	defer c.Quit()
-	if err := c.Mail(fmt.Sprintf("%s@%s", username, domain)); err != nil {
-		return http.StatusBadRequest, fmt.Errorf(fmt.Sprintf("Bad from email address: %s@%s", username, domain))
+	if err := c.Mail(fmt.Sprintf("%s@%s", from, domain)); err != nil {
+		return http.StatusBadRequest, fmt.Errorf(fmt.Sprintf("Bad from email address: %s@%s", from, domain))
 	}
 	if err := c.Rcpt(fmt.Sprintf("%s@%s", to, domain)); err != nil {
 		return http.StatusBadRequest, fmt.Errorf(fmt.Sprintf("Bad to email address: %s@%s", to, domain))
@@ -78,7 +77,7 @@ func sendMessage(username string, from string, to string, message string) (statu
 		return http.StatusBadRequest, fmt.Errorf(fmt.Sprintf("Bad data format: %s", err))
 	}
 	defer wc.Close()
-	buf := bytes.NewBufferString(fmt.Sprintf("From: %s@%s\r\nSubject: SMS sent by: \"%s\" from \"%s\" to \"%s\"\r\n\r\n%s", username, domain, username, from, to, message))
+	buf := bytes.NewBufferString(fmt.Sprintf("From: %s@%s\r\nSubject: SMS sent from \"%s\" to \"%s\"\r\n\r\n%s", from, domain, from, to, message))
 	if _, err = buf.WriteTo(wc); err != nil {
 		return http.StatusInternalServerError, fmt.Errorf(fmt.Sprintf("Error writing message body: %s", err))
 	}


### PR DESCRIPTION
W nowym api zamiast username i password jest przesyłany token w headerze, w związku z czym parametr username wylatuje. Działa ze starym api